### PR TITLE
Fix error when importing with Deno

### DIFF
--- a/packets/mod.ts
+++ b/packets/mod.ts
@@ -33,7 +33,7 @@ export type AnyPacket =
 
 export type AnyPacketWithLength = AnyPacket & { length: number };
 
-export {
+export type {
   ConnectPacket,
   ConnackPacket,
   PublishPacket,


### PR DESCRIPTION
Solves #3 

Exporting types require the `type` keyword to be present.

As Deno is now using `isolatedModules` flag.

Sorry I'm super noob with Deno :sweat_smile: 

note: My fix isn't a complete solution, but it at least allows Deno to run with the `--no-check` flag.