### PR TITLE
Fix undefined options on connection when code is minified

### DIFF
--- a/client/base_client.ts
+++ b/client/base_client.ts
@@ -977,7 +977,7 @@ export abstract class Client {
   }
 
   protected startReconnectTimer() {
-    const options = this.options;
+    const options = this.options || {};
 
     let reconnectOptions;
     let defaultOptions;


### PR DESCRIPTION
For some mysterious reason, I get the following error whenever I try to run the client in a minified deno code base.
```
2021-10-14T09:13:17.405Z Info     Client:  connectionState: offline -> connecting
2021-10-14T09:13:17.405Z Info     Client:  caught error opening connection: Cannot read properties of undefined (reading 'url')
2021-10-14T09:13:17.405Z Info     Client:  connectionState: connecting -> offline
error: Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'connect')
            reconnectOptions = options.connect || {
                                       ^
    at Client1.startReconnectTimer (file:///Users/medmouine/dc-iot/devices/simulators/temperature_sensor/src/bundle.js:5495:40)
    at Client1.openConnection (file:///Users/medmouine/dc-iot/devices/simulators/temperature_sensor/src/bundle.js:5244:23)
    at Client1.connect (file:///Users/medmouine/dc-iot/devices/simulators/temperature_sensor/src/bundle.js:4995:14)
    at connect (file:///Users/medmouine/dc-iot/devices/simulators/temperature_sensor/src/bundle.js:6197:47)
    at initMqttClient (file:///Users/medmouine/dc-iot/devices/simulators/temperature_sensor/src/bundle.js:6221:15)
    at file:///Users/medmouine/dc-iot/devices/simulators/temperature_sensor/src/bundle.js:6278:26
    at file:///Users/medmouine/dc-iot/devices/simulators/temperature_sensor/src/bundle.js:6287:3
```

The `|| {}` is only a quick patch. Would be great if you had any insights on the actual cause of the problem.

Thanks!

Setup:
- MacOS Big Sur 11.6
- Chip Apple M1
- Deno 1.14.2 (release, aarch64-apple-darwin)
- v8 9.4.146.15
- typescript 4.4.2